### PR TITLE
ingest-simulated butler command

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -35,22 +35,16 @@ jobs:
       - name: Install sqlite
         run: sudo apt-get install sqlite libyaml-dev
 
-      - name: Install sphgeom dependencies
-        run: pip install -r https://raw.githubusercontent.com/lsst/sphgeom/master/requirements.txt
-
       - name: Install dax_butler dependencies
         run: pip install -r https://raw.githubusercontent.com/lsst/daf_butler/master/requirements.txt
 
       # pytest-xdist allows to parallelize testing on multiple CPUs
       # pytest-openfiles allows to detect open I/O resources at the end of unit tests
-      - name: Install pytest-xdist and pytest-openfiles
-        run: pip install pytest-xdist pytest-openfiles
+      - name: Install pytest packages
+        run: pip install pytest pytest-flake8 pytest-xdist pytest-openfiles
 
-      # it's not possible to overwrite the default dimensions.yaml of the butler right now
-      # the workaround is to replace the default dimensions.yaml with ours
       - name: Build and install
         run: |
-          cp spherex_butler_poc/python/spherex/configs/dimensions.yaml daf_butler/python/lsst/daf/butler/configs/
           cd ${{ github.workspace }}/daf_butler
           pip install -v .
           cd ${{ github.workspace }}/spherex_butler_poc

--- a/python/spherex/cli/cmd/__init__.py
+++ b/python/spherex/cli/cmd/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["ingest_simulated"]
+
+from .commands import ingest_simulated

--- a/python/spherex/cli/cmd/commands.py
+++ b/python/spherex/cli/cmd/commands.py
@@ -1,0 +1,32 @@
+import click
+
+from lsst.daf.butler.cli.opt import (repo_argument,
+                                     locations_argument,
+                                     regex_option,
+                                     run_option,
+                                     transfer_option
+                                     )
+from lsst.daf.butler.cli.utils import (cli_handle_exception)
+from ... import script
+
+from lsst.daf.butler.cli.utils import MWArgumentDecorator
+instrument_argument = MWArgumentDecorator("instrument",
+                                          help="The name or fully-qualified class name of an instrument.")
+
+# default regular expression to find sumulated files
+rawexp_re = r"sim_exposure_(\d+)_array_(\d).fits"
+
+
+@click.command(short_help="Ingest simulated images.")
+@repo_argument(required=True)
+@locations_argument(help="LOCATIONS specifies files to ingest and/or locations to search for files.",
+                    required=True)
+@regex_option(default=rawexp_re,
+              help="Regex string used to find files in directories listed in LOCATIONS. "
+                   "Searches for fits files by default.")
+@run_option(required=False)
+@transfer_option()
+@click.option("--ingest-type", default="rawexp", help="Raw exposure images")
+def ingest_simulated(*args, **kwargs):
+    """Ingest raw frames into from a directory into the butler registry"""
+    cli_handle_exception(script.ingestSimulated, *args, **kwargs)

--- a/python/spherex/cli/resources.yaml
+++ b/python/spherex/cli/resources.yaml
@@ -1,0 +1,7 @@
+# The butler command finds plugin commands by way of a resource manifest
+# https://pipelines.lsst.io/v/weekly/modules/lsst.daf.butler/writing-subcommands.html#adding-butler-subcommands
+# the location of this file must be references by DAF_BUTLER_PLUGINS environment variable
+cmd:
+  import: spherex.cli.cmd
+  commands:
+    - ingest-simulated

--- a/python/spherex/configs/butler.yaml
+++ b/python/spherex/configs/butler.yaml
@@ -1,0 +1,21 @@
+datastore:
+  # Want to check disassembly so can't use InMemory
+  cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+  formatters:
+    MyImage: spherex.formatters.astropy_image.AstropyImageFormatter
+    SPHERExImage: spherex.formatters.astropy_image.AstropyImageFormatter
+  templates:
+    default: "{run:/}/{datasetType}.{component:?}/{label:?}/{detector:?}/{exposure.group_name:?}/{datasetType}_{component:?}_{label:?}_{calibration_label:?}_{exposure:?}_{detector:?}_{instrument:?}_{skypix:?}_{run}"
+
+storageClasses:
+  MyImage:
+    pytype: astropy.io.fits.HDUList
+  SPHERExImage:
+    pytype: astropy.io.fits.HDUList
+
+registry:
+  # File-based:
+  #   db: 'sqlite:///<butlerRoot>/mytest.sqlite3'
+  # In-memory (in process of being phased out):
+  #   db: 'sqlite:///:memory:'
+  db: 'sqlite:///<butlerRoot>/spherex.sqlite3'

--- a/python/spherex/configs/dimensions.yaml
+++ b/python/spherex/configs/dimensions.yaml
@@ -1,150 +1,164 @@
-dimensions:
-  version: 0
-  skypix:
-    common: htm7
-    htm7:
-      class: lsst.sphgeom.HtmPixelization
-      level: 7
-    htm9:
-      class: lsst.sphgeom.HtmPixelization
-      level: 9
+version: 0
+skypix:
+  # 'common' is the skypix system and level used to relate all other spatial
+  # dimensions.  Its value is a string formed by concatenating one of the
+  # other keys under the 'skypix' headerin (i.e. the name of a skypix system)
+  # with an integer level (with no zero-padding).
+  common: htm7
+  htm:
+    class: lsst.sphgeom.HtmPixelization
+    max_level: 24
 
-  elements:
-    instrument:
-      doc: >
-        An entity that produces observations.  An instrument defines a set of
-        detectors and a numbering system for the exposures.
-      keys:
-        -
-          name: name
-          type: string
-          length: 16
-      metadata:
-        -
-          name: exposure_max
-          type: int
-          doc: >
-            Maximum value for the 'exposure' field for exposures associated with
-            this instrument (exclusive).
-        -
-          name: detector_max
-          type: int
-          doc: >
-            Maximum value for the 'detector' field for detectors associated with
-            this instrument (exclusive).
-        -
-          name: class_name
-          type: string
-          length: 64
-          doc: >
-            Full class name of the Instrument class associated with this
-            instrument.
-      cached: true
+elements:
+  instrument:
+    doc: >
+      An entity that produces observations.  An instrument defines a set of
+      detectors and a numbering system for the exposures.
+    keys:
+      -
+        name: name
+        type: string
+        length: 16
+    metadata:
+      -
+        name: exposure_max
+        type: int
+        doc: >
+          Maximum value for the 'exposure' field for exposures associated with
+          this instrument (exclusive).
+      -
+        name: detector_max
+        type: int
+        doc: >
+          Maximum value for the 'detector' field for detectors associated with
+          this instrument (exclusive).
+      -
+        name: class_name
+        type: string
+        length: 64
+        doc: >
+          Full class name of the Instrument class associated with this
+          instrument.
+    governor: true
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.governor.BasicGovernorDimensionRecordStorage
 
-    detector:
-      doc: >
-        A detector associated with a particular instrument (not an observation
-        of that detector; that requires specifying an exposure as well).
-      keys:
-        -
-          name: id
-          type: int
-        -
-          name: full_name
-          type: string
-          length: 32
-      requires: [instrument]
-      metadata:
-        -
-          name: lmin
-          type: float
-          doc: >
-            Minimum wavelength.
-        -
-          name: lmax
-          type: float
-          doc: >
-            Maximum wavelength.
-        -
-          name: r
-          type: float
-          doc: >
-            Resolution.
-        -
-          name: desc
-          type: string
-          length: 32
-          doc: >
-            Description of the detector.
-      cached: true
+  detector:
+    doc: >
+      A detector associated with a particular instrument (not an observation
+      of that detector; that requires specifying an exposure as well).
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: full_name
+        type: string
+        length: 32
+    requires: [instrument]
+    metadata:
+      -
+        name: lmin
+        type: float
+        doc: >
+          Minimum wavelength.
+      -
+        name: lmax
+        type: float
+        doc: >
+          Maximum wavelength.
+      -
+        name: r
+        type: float
+        doc: >
+          Resolution.
+      -
+        name: desc
+        type: string
+        length: 32
+        doc: >
+          Description of the detector.
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.caching.CachingDimensionRecordStorage
+      nested:
+        cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
 
-    exposure:
-      doc: >
-        An observation associated with a particular instrument.
-        All direct observations are identified with an exposure.
-      keys:
-        -
-          name: id
-          type: int
-        -
-          name: name
-          type: string
-          length: 64
-      requires: [instrument]
-      temporal: exposure
-      metadata:
-        -
-          name: exposure_time
-          type: float
-          doc: Duration of the exposure with shutter open (seconds).
-        -
-          name: group_name
-          type: string
-          length: 64
-          doc: >
-            String group identifier associated with this exposure by the
-            acquisition system.
-        -
-          name: group_id
-          type: int
-          doc: >
-            Integer group identifier associated with this exposure by the
-            acquisition system.
-        -
-          name: ra_boresight
-          type: float
-          doc: >
-            ICRS Right Ascension of boresight in degrees.
-        -
-          name: dec_boresight
-          type: float
-          doc: >
-            ICRS Declination of boresight in degrees.
-        -
-          name: roll
-          type: float
-          doc: >
-            Angle of the instrument focal plane on the sky in degrees.
-        -
-          name: gaussian_jitter
-          type: float
-          doc: >
-            Mean sigma in arcseconds.
+  exposure:
+    doc: >
+      An observation associated with a particular instrument.
+      All direct observations are identified with an exposure.
+    keys:
+      -
+        name: id
+        type: int
+      -
+        name: name
+        type: string
+        length: 64
+    requires: [instrument]
+    metadata:
+      -
+        name: exposure_time
+        type: float
+        doc: Duration of the exposure with shutter open (seconds).
+      -
+        name: group_name
+        type: string
+        length: 64
+        doc: >
+          String group identifier associated with this exposure by the
+          acquisition system.
+      -
+        name: group_id
+        type: int
+        doc: >
+          Integer group identifier associated with this exposure by the
+          acquisition system.
+      -
+        name: ra_boresight
+        type: float
+        doc: >
+          ICRS Right Ascension of boresight in degrees.
+      -
+        name: dec_boresight
+        type: float
+        doc: >
+          ICRS Declination of boresight in degrees.
+      -
+        name: roll
+        type: float
+        doc: >
+          Angle of the instrument focal plane on the sky in degrees.
+      -
+        name: gaussian_jitter
+        type: float
+        doc: >
+          Mean sigma in arcseconds.
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
 
-    calibration_label:
-      doc: >
-        A string label that maps to a date validity range for master
-        calibration products.
-      keys:
-        -
-          name: name
-          type: string
-          length: 128
-      requires: [instrument]
-      temporal: calibration_label
+  calibration_label:
+    doc: >
+      A string label that maps to a date validity range for master
+      calibration products.
+    keys:
+      -
+        name: name
+        type: string
+        length: 128
+    requires: [instrument]
+    storage:
+      cls: lsst.daf.butler.registry.dimensions.table.TableDimensionRecordStorage
 
-  packers:
-    exposure_detector:
-      fixed: [instrument]
-      dimensions: [instrument, exposure, detector]
-      cls: lsst.daf.butler.instrument.ObservationDimensionPacker
+topology:
+  spatial:
+    observation_regions: []
+    skymap_regions: []
+  temporal:
+    observation_timespans: [exposure, calibration_label]
+
+packers:
+  exposure_detector:
+    fixed: [instrument]
+    dimensions: [instrument, exposure, detector]
+    cls: lsst.daf.butler.instrument.ObservationDimensionPacker

--- a/python/spherex/formatters/astropy_image.py
+++ b/python/spherex/formatters/astropy_image.py
@@ -12,7 +12,8 @@ from lsst.daf.butler.formatters.file import FileFormatter
 
 
 class AstropyImageFormatter(FileFormatter):
-    """Interface for reading and writing astropy image objects to and from FITS files.
+    """Interface for reading and writing astropy
+    image objects to and from FITS files.
     """
 
     extension = ".fits"
@@ -45,7 +46,7 @@ class AstropyImageFormatter(FileFormatter):
         return data
 
     def _writeFile(self, inMemoryDataset: Any) -> None:
-        """Write the in memory dataset to file on disk.
+        """Write in memory dataset to file on disk.
 
         Parameters
         ----------
@@ -60,78 +61,3 @@ class AstropyImageFormatter(FileFormatter):
         if not isinstance(inMemoryDataset, fits.HDUList):
             raise NotImplementedError("Unable to write this representation of FITS into a file.")
         inMemoryDataset.writeto(self.fileDescriptor.location.path)
-
-    # todo: do we need to implement _fromBytes, _toBytes, and _coerceType? When are they used?
-    # import builtins
-    # import pickle
-    # if TYPE_CHECKING:
-    #     from lsst.daf.butler import StorageClass
-    #
-    # def _fromBytes(self, serializedDataset: bytes, pytype: Optional[Type[Any]] = None) -> Any:
-    #     """Read the bytes object as a python object.
-    #
-    #     Parameters
-    #     ----------
-    #     serializedDataset : `bytes`
-    #         Bytes object to unserialize.
-    #     pytype : `class`, optional
-    #         Not used by this implementation.
-    #
-    #     Returns
-    #     -------
-    #     inMemoryDataset : `object`
-    #         The requested data as a Python object or None if the string could
-    #         not be read.
-    #     """
-    #     try:
-    #         data = pickle.loads(serializedDataset)
-    #     except pickle.PicklingError:
-    #         data = None
-    #
-    #     return data
-    #
-    # def _toBytes(self, inMemoryDataset: Any) -> bytes:
-    #     """Write the in memory dataset to a bytestring.
-    #
-    #     Parameters
-    #     ----------
-    #     inMemoryDataset : `object`
-    #         Object to serialize
-    #
-    #     Returns
-    #     -------
-    #     serializedDataset : `bytes`
-    #         bytes representing the serialized dataset.
-    #
-    #     Raises
-    #     ------
-    #     Exception
-    #         The object could not be serialized.
-    #     """
-    #     return pickle.dumps(inMemoryDataset, protocol=-1)
-    #
-    # def _coerceType(self, inMemoryDataset: Any, storageClass: StorageClass,
-    #                 pytype: Optional[Type[Any]] = None) -> Any:
-    #     """Coerce the supplied inMemoryDataset to type `pytype`.
-    #
-    #     Parameters
-    #     ----------
-    #     inMemoryDataset : `object`
-    #         Object to coerce to expected type.
-    #     storageClass : `StorageClass`
-    #         StorageClass associated with `inMemoryDataset`.
-    #     pytype : `type`, optional
-    #         Override type to use for conversion.
-    #
-    #     Returns
-    #     -------
-    #     inMemoryDataset : `object`
-    #         Object of expected type `pytype`.
-    #     """
-    #     if pytype is not None and not hasattr(builtins, pytype.__name__):
-    #         if storageClass.isComposite():
-    #             inMemoryDataset = storageClass.assembler().assemble(inMemoryDataset, pytype=pytype)
-    #         elif not isinstance(inMemoryDataset, pytype):
-    #             # Hope that we can pass the arguments in directly
-    #             inMemoryDataset = pytype(inMemoryDataset)
-    #     return inMemoryDataset

--- a/python/spherex/script/__init__.py
+++ b/python/spherex/script/__init__.py
@@ -1,0 +1,1 @@
+from .ingestSimulated import ingestSimulated

--- a/python/spherex/script/ingestSimulated.py
+++ b/python/spherex/script/ingestSimulated.py
@@ -1,0 +1,128 @@
+import re
+import datetime
+
+from lsst.daf.butler.core.utils import findFileResources
+
+from lsst.daf.butler import (
+    Butler,
+    CollectionType,
+    DataCoordinate,
+    DatasetRef,
+    DatasetType,
+    FileDataset,
+    Timespan
+)
+
+from ..formatters.astropy_image import AstropyImageFormatter
+
+
+def ingestSimulated(repo, locations, regex, output_run, transfer="auto", ingest_type="rawexp"):
+    """Ingests raw frames into the butler registry
+
+    Parameters
+    ----------
+    repo : `str`
+        URI to the repository.
+    locations : `list` [`str`]
+        Files to ingest and directories to search for files that match
+        ``regex`` to ingest.
+    regex : `str`
+        Regex string used to find files in directories listed in locations.
+    output_run : `str`
+        The path to the location, the run, where datasets should be put.
+    transfer : `str` or None
+        The external data transfer type, by default "auto".
+    ingest_type : `str`
+        ingest product data type.
+
+    Raises
+    ------
+    Exception
+        Raised if operations on configuration object fail.
+
+    Notes
+    -----
+    This method inserts all datasets for an exposure within a transaction,
+    guaranteeing that partial exposures are never ingested.  The exposure
+    dimension record is inserted with `Registry.syncDimensionData` first
+    (in its own transaction), which inserts only if a record with the same
+    primary key does not already exist.  This allows different files within
+    the same exposure to be incremented in different runs.
+    """
+
+    butler = Butler(repo, writeable=True)
+
+    # make sure instrument and detector dimensions are populated
+    with butler.registry.transaction():
+        instrument_record = {
+            "name": "simulator",
+            "exposure_max": 600000,
+            "detector_max": 6
+        }
+        butler.registry.syncDimensionData("instrument", instrument_record)
+        for idx in range(1, 7):
+            detector_record = {
+                "instrument": "simulator",
+                "id": idx,
+                "full_name": f"array{idx}"
+            }
+            butler.registry.syncDimensionData("detector", detector_record)
+
+    dimension_universe = butler.registry.dimensions
+    datasetType = DatasetType(ingest_type,
+                              dimension_universe.extract(("instrument", "detector", "exposure")),
+                              "SPHERExImage",
+                              universe=dimension_universe)
+    # idempotent dataset type registration
+    butler.registry.registerDatasetType(datasetType)
+
+    # idempotent collection registration
+    run = f"{ingest_type}r" if (output_run is None) else output_run
+    butler.registry.registerCollection(run, type=CollectionType.RUN)
+
+    n_failed = 0
+    files = findFileResources(locations, regex)
+
+    # example: sim_exposure_000000_array_1.fits or
+    #   sim_exposure_000000_array_2_dark_current.fits
+    pattern = re.compile(r"sim_exposure_(\d+)_array_(\d)[_,.]")
+
+    # do we want to group observations?
+    grp = datetime.date.today().strftime("%Y%m%d")
+
+    datasets = []
+    for file in files:
+        # parse exposure and detector ids from file name
+        m = pattern.search(file)
+        if m is None:
+            n_failed += 1
+            continue
+        else:
+            g = m.groups()
+            if len(g) != 2:
+                n_failed += 1
+                continue
+            else:
+                [exposure_id, detector_id] = list(map(int, g))
+
+        try:
+            exposure_record = {"instrument": "simulator",
+                               "id": exposure_id,
+                               "name": f"{exposure_id:06d}",
+                               "group_name": f"{grp}",
+                               "timespan": Timespan(begin=None, end=None)}
+            # idempotent insertion of individual dimension rows
+            butler.registry.syncDimensionData("exposure", exposure_record)
+        except Exception as e:  # noqa: F841
+            n_failed += 1
+            continue
+
+        dataId = DataCoordinate.standardize(instrument="simulator",
+                                            detector=detector_id,
+                                            exposure=exposure_id,
+                                            universe=butler.registry.dimensions)
+        ref = DatasetRef(datasetType, dataId=dataId)
+        datasets.append(FileDataset(refs=ref, path=file, formatter=AstropyImageFormatter))
+
+    with butler.transaction():
+        butler.ingest(*datasets, transfer=transfer, run=run)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,50 @@
+[metadata]
+name = spherex_butler_poc
+description = Proof-of-concept code for using Rubin/LSST Gen3 Butler framework in SPHEREx pipelines
+author = SPHEREx Science Data Center
+url = https://github.com/Caltech-IPAC/spherex_butler_poc
+classifiers =
+    Intended Audience :: Science/Research
+    License :: OSI Approved ::  GNU General Public License v3 or later (GPLv3+)
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Topic :: Scientific/Engineering :: Astronomy
+
+[options]
+zip_safe = True
+package_dir=
+    =python
+packages=find:
+setup_requires =
+  setuptools >=46.0
+install_requires =
+  astropy >=4.0
+  click >= 7.0
+  daf_butler @ git+https://github.com/lsst/daf_butler@master
+tests_require =
+  pytest >= 3.2
+  flake8 >= 3.7.5
+  pytest-flake8 >= 1.0.4
+  pytest-openfiles >= 0.5.0
+
+[options.packages.find]
+where=python
+
+[options.package_data]
+spherex = configs/*.yaml, configs/*/*.yaml
+
+[flake8]
+max-line-length = 110
+max-doc-length = 79
+ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503
+exclude = __init__.py
+    lex.py
+    yacc.py
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N815 N816 W503
+# The matplotlib test may not release font files.
+# Some unit tests open registry database in setUpClass.
+open_files_ignore = "*.ttf" "*.sqlite3"

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,14 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 version = "0.0.1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-# packages are organized according to PEP-420: https://www.python.org/dev/peps/pep-0420/
-# see https://setuptools.readthedocs.io/en/latest/setuptools.html#find-namespace-packages
-setup (
-    name="spherex_butler_poc",
-    provides="spherex_butler_poc",
+# packages are organized according to PEP-420:
+#    https://www.python.org/dev/peps/pep-0420/
+setup(
     version=version,
-    description="Proof-of-concept code for using LSST Gen3 Butler in SPHEREx pipelines",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/Caltech-IPAC/spherex_butler_poc",
-    packages=find_packages(where="python"),
-    package_dir={"": "python"},
-    python_requires=">3.6",
-    setup_requires=["setuptools >=49.2", ],
-    install_requires=["astropy >=4.0", ],
-    # install_requires=["astropy >=4.0", "daf-butler @ https://github.com/lsst/daf_butler/archive/master.tar.gz"],
 )

--- a/ups/spherex_butler_poc.table
+++ b/ups/spherex_butler_poc.table
@@ -1,0 +1,6 @@
+setupRequired(daf_butler)
+
+envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
+envPrepend(PATH, ${PRODUCT_DIR}/bin)
+envPrepend(DAF_BUTLER_PLUGINS, ${PRODUCT_DIR}/python/spherex/cli/resources.yaml)
+envPrepend(DAF_BUTLER_CONFIG_PATHS, ${PRODUCT_DIR}/python/spherex/config)


### PR DESCRIPTION
- added ingest-simulated butler command
- dimensions.yaml is no longer a part of butler config
- using setup.cfg for package and tool options
- running flake8 as a part of pytest in GitHub unit test

Testing in a directory parralel to spherex_butler_poc with simulator data.

1. Create empty butler repository:
```
butler create --override --seed-config ../spherex_butler_poc/python/spherex/configs/butler.yaml --dimension-config ../spherex_butler_poc/python/spherex/configs/dimensions.yaml DATA
```

2. Ingest simulated images:
```
butler ingest-simulated DATA /Users/tatianag/lsst/test_spherex/simulator_files
```

3. Ingest dark current images (the group is set to the ingest date, hence ingesting raw and dark images should be done on the same date):
```
butler ingest-simulated --regex dark_current.fits --ingest-type dark DATA /Users/tatianag/lsst/test_spherex/simulator_files
```

4. Examine butler database
```
sqlite3 DATA/spherex.sqlite3
> .header on
> .tables
> select * from file_datastore_records;
> .exit
```
