### PR TITLE
SP-69 Create initial prototype for SPHEREx LVF image class

### DIFF
--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -30,13 +30,17 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install sqlite
         run: sudo apt-get install sqlite libyaml-dev
 
+      - name: Override datastores files
+        # physical_filter+detector+exposure in the original fileDatastore creates problem
+        run: cp ${{ github.workspace }}/spherex_butler_poc/python/spherex/configs/datastores/*  ${{ github.workspace }}/daf_butler/python/lsst/daf/butler/configs/datastores/
+
       - name: Install dax_butler dependencies
-        run: pip install -r https://raw.githubusercontent.com/lsst/daf_butler/master/requirements.txt
+        run: pip install -r ${{ github.workspace }}/daf_butler/requirements.txt
 
       # pytest-xdist allows to parallelize testing on multiple CPUs
       # pytest-openfiles allows to detect open I/O resources at the end of unit tests

--- a/python/spherex/configs/butler.yaml
+++ b/python/spherex/configs/butler.yaml
@@ -2,16 +2,19 @@ datastore:
   # Want to check disassembly so can't use InMemory
   cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
   formatters:
-    MyImage: spherex.formatters.astropy_image.AstropyImageFormatter
-    SPHERExImage: spherex.formatters.astropy_image.AstropyImageFormatter
+    MyImage: spherex.formatters.AstropyImageFormatter
+    CCDData: spherex.formatters.CCDDataFormatter
+    SPHERExImage: spherex.formatters.SPHERExImageFormatter
   templates:
     default: "{run:/}/{datasetType}.{component:?}/{label:?}/{detector:?}/{exposure.group_name:?}/{datasetType}_{component:?}_{label:?}_{calibration_label:?}_{exposure:?}_{detector:?}_{instrument:?}_{skypix:?}_{run}"
 
 storageClasses:
   MyImage:
     pytype: astropy.io.fits.HDUList
+  CCDData:
+    pytype: astropy.nddata.CCDData
   SPHERExImage:
-    pytype: astropy.io.fits.HDUList
+    pytype: spherex.core.SPHERExImage
 
 registry:
   # File-based:

--- a/python/spherex/configs/datastores/fileDatastore.yaml
+++ b/python/spherex/configs/datastores/fileDatastore.yaml
@@ -1,0 +1,11 @@
+# this file overrides the fileDatastore.yaml in daf_butler repo
+datastore:
+  cls: lsst.daf.butler.datastores.fileDatastore.FileDatastore
+  root: <butlerRoot>/datastore
+  records:
+    table: file_datastore_records
+  create: true
+  templates:
+    default: "{run:/}/{datasetType}.{component:?}/{label:?}/{detector:?}/{exposure.group_name:?}/{datasetType}_{component:?}_{label:?}_{calibration_label:?}_{exposure:?}_{detector:?}_{instrument:?}_{skypix:?}_{run}"
+  formatters: !include formatters.yaml
+  composites: !include composites.yaml

--- a/python/spherex/configs/datastores/formatters.yaml
+++ b/python/spherex/configs/datastores/formatters.yaml
@@ -1,0 +1,27 @@
+# This file gives the mapping between DatasetType and the
+# `lsst.daf.butler.Formatter` that handles it.
+# this file overrides the formatters.yaml in daf_butler repo
+write_recipes: !include writeRecipes.yaml
+default:
+  lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter:
+    # default is the default recipe regardless but this demonstrates
+    # how to specify a default write parameter
+    recipe: default
+PropertyList:
+  formatter: lsst.daf.butler.formatters.yaml.YamlFormatter
+  parameters:
+    unsafe_dump: true
+PropertySet:
+  formatter: lsst.daf.butler.formatters.yaml.YamlFormatter
+  parameters:
+    unsafe_dump: true
+NumpyArray: lsst.daf.butler.formatters.pickle.PickleFormatter
+Plot: lsst.daf.butler.formatters.matplotlib.MatplotlibFormatter
+MetricValue:
+  formatter: lsst.daf.butler.formatters.yaml.YamlFormatter
+  parameters:
+    unsafe_dump: true
+BrighterFatterKernel: lsst.daf.butler.formatters.pickle.PickleFormatter
+StructuredDataDict: lsst.daf.butler.formatters.yaml.YamlFormatter
+AstropyTable: lsst.daf.butler.formatters.astropyTable.AstropyTableFormatter
+AstropyQTable: lsst.daf.butler.formatters.astropyTable.AstropyTableFormatter

--- a/python/spherex/core/__init__.py
+++ b/python/spherex/core/__init__.py
@@ -1,0 +1,4 @@
+import pkgutil
+__path__ = pkgutil.extend_path(__path__, __name__)
+
+from .spherex_image import *

--- a/python/spherex/core/spherex_image.py
+++ b/python/spherex/core/spherex_image.py
@@ -1,0 +1,270 @@
+from astropy.io import fits, registry
+from astropy.nddata import CCDData, fits_ccddata_reader, FlagCollection
+
+__all__ = ['SPHERExImage', 'spherex_image_reader', 'spherex_image_writer']
+
+FLAG_DEFS = {
+    'NONFUNC': 2,
+    'COSMICRAY': 1,
+    'SATURATED': 0,
+    'HOT': 3,
+    'OUTLIER': 4,
+    'DARKREF': 5,
+    'PERSISTENT': 6
+}
+
+
+class SPHERExImage(CCDData):
+    """Container class for SPHEREx image components
+
+    It contains SPHEREx image components, such as ccd data, flags, etc.
+    and provides support for reading and writing SPHERExImage from/to FITS.
+
+    Parameters
+    ----------
+    data : `~astropy.nddata.NDData`-like or `numpy.ndarray`-like
+        CCD data contained in this object.
+        Note that the data will always be saved by *reference*, so you should
+        make a copy of the ``data`` before passing it in if that's the desired
+        behavior.
+
+    flags : `numpy.ndarray` or `~astropy.nddata.FlagCollection` or None, \
+            optional
+        Flags giving information about each pixel. These can be specified
+        either as a Numpy array of any type with a shape matching that of the
+        data, or as a `~astropy.nddata.FlagCollection` instance which has a
+        shape matching that of the data.
+        Default is ``None``.
+
+    wcs : `~astropy.wcs.WCS` or None, optional
+        WCS-object containing the world coordinate system for the data.
+        Default is ``None``.
+
+    meta : dict-like object or None, optional
+        Metadata for this object. "Metadata" here means all information that
+        is included with this object but not part of any other attribute
+        of this particular object, e.g. creation date, unique identifier,
+        simulation parameters, exposure time, telescope name, etc.
+
+    unit : `~astropy.units.Unit` or str, optional
+        The units of the data.
+        Default is ``None``.
+
+        .. warning::
+
+            If the unit is ``None`` or not otherwise specified it will raise a
+            ``ValueError``
+
+    Methods
+    -------
+    read(\\*args, \\**kwargs)
+        ``Classmethod`` to create an SPHERExImage instance based on a ``FITS`` file.
+        This method uses :func:`spherex_fits_reader` with the provided
+        parameters.
+    write(\\*args, \\**kwargs)
+        Writes the contents of the SPHERExImage instance into a new ``FITS`` file.
+        This method uses :func:`spherex_fits_writer` with the provided
+        parameters.
+    """
+
+    def __init__(self, *args, **kwargs):
+        if 'flags' in kwargs and isinstance(kwargs['flags'], FlagCollection):
+            raise NotImplementedError('Flag collection is not supported')
+        if 'flag_defs' in kwargs:
+            self._flag_defs = kwargs.pop('flag_defs')
+        super().__init__(*args, **kwargs)
+
+    @property
+    def flag_defs(self):
+        return self._flag_defs
+
+    @flag_defs.setter
+    def flag_defs(self, value):
+        self._flag_defs = value
+
+
+def get_flag_defs(header: fits.Header):
+    """Get flag definition dictionary from the the header
+
+    Parameters
+    ----------
+    header : dict-like object
+
+    Returns
+    -------
+    flag_defs : dict-like object
+
+    """
+    flag_defs = {}
+    for key, val in header.items():
+        if key.startswith('MP_'):
+            try:
+                intval = int(val)
+                if intval > 31:
+                    raise ValueError(f'bit value {intval} for flag {key}'
+                                     ' is too large')
+                flagkey = key[3:]
+                flag_defs[flagkey] = intval
+            except ValueError:
+                pass
+    if len(flag_defs) > 0:
+        return flag_defs
+
+
+def add_flag_defs(spherex_image: SPHERExImage, header: fits.Header) -> None:
+    """Add image flag definitions to the header
+
+    Parameters
+    ----------
+    spherex_image : `~spherex.data.SPHERExImage`
+    header : dict-like object
+
+    """
+
+    # check for None or empty dictionary
+    if not spherex_image.flag_defs:
+        return
+
+    # convention understood by Firefly:
+    # EXTTYPE=MASK and flag bit values in keywords starting with "MP_"
+    header['EXTTYPE'] = 'MASK'
+    for key, val in spherex_image.flag_defs.items():
+        prefix = 'MP_' if len(key) < 6 else 'HIERARCH MP_'
+        header[f'{prefix}{key.upper()}'] = val
+
+
+def spherex_image_reader(filename, hdu=0, unit=None, hdu_uncertainty='VARIANCE',
+                         hdu_mask='MASK', hdu_flags='FLAGS',
+                         key_uncertainty_type='UTYPE', **kwd) -> SPHERExImage:
+    """
+    Generate a SPHERExImage object from a FITS file.
+
+    Parameters
+    ----------
+    filename : str
+        Name of fits file.
+
+    hdu : str or int, optional
+        FITS extension from which the data should be initialized. If zero and
+        and no data in the primary extension, it will search for the first
+        extension with data. The header will be added to the primary header.
+        Default is ``0``.
+
+    unit : `~astropy.units.Unit`, optional
+        Units of the image data. If this argument is provided and there is a
+        unit for the image in the FITS header (the keyword ``BUNIT`` is used
+        as the unit, if present), this argument is used for the unit.
+        Default is ``None``.
+
+    hdu_uncertainty : str or int or None, optional
+        FITS extension from which the uncertainty should be initialized. If the
+        extension does not exist the uncertainty of the SPHERExImage is ``None``.
+        Default is ``'VARIANCE'``.
+
+    hdu_mask : str or int or None, optional
+        FITS extension from which the mask should be initialized. If the
+        extension does not exist the mask of the SPHERExImage is ``None``.
+        Default is ``'MASK'``.
+
+    hdu_flags : str or int or None, optional
+        FITS extension from which the flags should be initialized. If the
+        extension does not exist the flags of the SPHERExImage is ``None``.
+        Default is ``FLAGS``.
+
+    key_uncertainty_type : str, optional
+        The header key name where the class name of the uncertainty  is stored
+        in the hdu of the uncertainty (if any).
+        Default is ``UTYPE``.
+
+    kwd :
+        Any additional keyword parameters are passed through to the FITS reader
+        in :mod:`astropy.io.fits`; see Notes for additional discussion.
+
+    Returns
+    -------
+    spherex_image : `~spherex.data.SPHERExImage`
+
+    Notes
+    -----
+    FITS files that contained scaled data (e.g. unsigned integer images) will
+    be scaled and the keywords used to manage scaled data in
+    :mod:`astropy.io.fits` are disabled.
+    """
+
+    ccddata = fits_ccddata_reader(filename, hdu=hdu, unit=unit,
+                                  hdu_uncertainty=hdu_uncertainty,
+                                  hdu_mask=hdu_mask,
+                                  key_uncertainty_type=key_uncertainty_type, **kwd)
+
+    flags = None
+    flag_defs = None
+    with fits.open(filename, **kwd) as hdus:
+        if hdu_flags is not None and hdu_flags in hdus:
+            flags_hdu = hdus[hdu_flags]
+            flags = flags_hdu.data
+            hdr = hdus[hdu_flags].header
+            flag_defs = get_flag_defs(hdr)
+
+        spherex_image = SPHERExImage(ccddata.data, meta=ccddata.header,
+                                     unit=ccddata.unit, mask=ccddata.mask,
+                                     uncertainty=ccddata.uncertainty,
+                                     wcs=ccddata.wcs, flags=flags,
+                                     flag_defs=flag_defs)
+    return spherex_image
+
+
+def spherex_image_writer(spherex_image: SPHERExImage, fileobj, hdu_mask='MASK', hdu_uncertainty='VARIANCE',
+                         hdu_flags='FLAGS', wcs_relax=True, key_uncertainty_type='UTYPE', **kwd):
+    """Write `~spherex.core.SPHERExImage` to a file
+
+    Parameters
+    ----------
+    spherex_image : `~spherex.core.SPHERExImage`
+
+    fileobj : file-like object or filename
+
+    hdu_mask, hdu_uncertainty, hdu_flags : str or None, optional
+        If it is a string append this attribute to the HDUList as
+        `~astropy.io.fits.ImageHDU` with the string as extension name.
+        Default is ``'MASK'`` for mask, ``'VARIANCE'`` for uncertainty and
+        ``'FLAGS'`` for flags
+
+    wcs_relax : bool
+        Value of the ``relax`` parameter to use in converting the WCS to a
+        FITS header using `~astropy.wcs.WCS.to_header`. The common
+        ``CTYPE`` ``RA---TAN-SIP`` and ``DEC--TAN-SIP`` requires
+        ``relax=True`` for the ``-SIP`` part of the ``CTYPE`` to be
+        preserved.
+
+    key_uncertainty_type : str, optional
+        The header key name for the class name of the uncertainty (if any)
+        that is used to store the uncertainty type in the uncertainty hdu.
+        Default is ``UTYPE``.
+
+    kwd : dict
+
+    Returns
+    -------
+
+    """
+
+    # to_hdu does not support flags at the moment
+    hdulist = spherex_image.to_hdu(hdu_mask=hdu_mask, hdu_uncertainty=hdu_uncertainty,
+                                   wcs_relax=wcs_relax, key_uncertainty_type=key_uncertainty_type)
+
+    # add flags hdu
+    if hdu_flags and spherex_image.flags is not None:
+        hdr_flags = fits.Header()
+        add_flag_defs(spherex_image, hdr_flags)
+
+        hdu = fits.ImageHDU(spherex_image.flags.data, hdr_flags, name=hdu_flags)
+        hdulist.append(hdu)
+
+    hdulist.writeto(fileobj, **kwd)
+
+
+# Register read/write methods for SPHERExImage
+with registry.delay_doc_updates(SPHERExImage):
+    registry.register_reader(data_format='fits', data_class=SPHERExImage, function=spherex_image_reader)
+    registry.register_writer(data_format='fits', data_class=SPHERExImage, function=spherex_image_writer)
+    registry.register_identifier(data_format='fits', data_class=SPHERExImage, identifier=fits.connect.is_fits)

--- a/python/spherex/formatters/__init__.py
+++ b/python/spherex/formatters/__init__.py
@@ -1,2 +1,6 @@
 import pkgutil
 __path__ = pkgutil.extend_path(__path__, __name__)
+
+from .astropy_image import *
+from .ccddata_image import *
+from .spherex_image import *

--- a/python/spherex/formatters/spherex_image.py
+++ b/python/spherex/formatters/spherex_image.py
@@ -1,16 +1,18 @@
-__all__ = ["AstropyImageFormatter"]
+__all__ = ["SPHERExImageFormatter"]
 
-from astropy.io import fits
 from typing import (
     Any,
     Optional,
     Type,
 )
 
+from astropy import units as u
 from lsst.daf.butler.formatters.file import FileFormatter
 
+from ..core import SPHERExImage, spherex_image_reader, spherex_image_writer
 
-class AstropyImageFormatter(FileFormatter):
+
+class SPHERExImageFormatter(FileFormatter):
     """Interface for reading and writing astropy
     image objects to and from FITS files.
     """
@@ -38,7 +40,7 @@ class AstropyImageFormatter(FileFormatter):
         """
         # todo check pytype?
         try:
-            data = fits.open(path)
+            data = spherex_image_reader(path, unit=(u.electron / u.s))
         except FileNotFoundError:
             data = None
 
@@ -57,6 +59,6 @@ class AstropyImageFormatter(FileFormatter):
         Exception
             The file could not be written.
         """
-        if not isinstance(inMemoryDataset, fits.HDUList):
+        if not isinstance(inMemoryDataset, SPHERExImage):
             raise NotImplementedError("Unable to write this representation of FITS into a file.")
-        inMemoryDataset.writeto(self.fileDescriptor.location.path)
+        spherex_image_writer(inMemoryDataset, self.fileDescriptor.location.path)

--- a/python/spherex/script/ingestSimulated.py
+++ b/python/spherex/script/ingestSimulated.py
@@ -98,7 +98,7 @@ def ingestSimulated(repo, locations, regex, output_run, transfer="auto", ingest_
         m = pattern.search(file)
         if m is None:
             n_failed += 1
-            logging.error(f"{file} does not match sumulator file pattern")
+            logging.error(f"{file} does not match simulator file pattern")
             continue
         else:
             g = m.groups()

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ spherex = configs/*.yaml, configs/*/*.yaml
 
 [flake8]
 max-line-length = 110
-max-doc-length = 79
+max-doc-length = 88
 ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503
 exclude = __init__.py
     lex.py

--- a/tests/test_spherex_image.py
+++ b/tests/test_spherex_image.py
@@ -46,10 +46,11 @@ class TestSPHERExImage(unittest.TestCase):
                              hdu_flags='FLAGS', wcs_relax=True, key_uncertainty_type='UTYPE')
 
         with fits.open(out_path) as hdulist:
-            # Primary extension contains data
+            # Primary extension - header only
+            # first extension - data
             # second extension - variance
-            # third extension - mask
-            self.assertEqual(len(hdulist), 3)
+            # third extension - flags
+            self.assertEqual(len(hdulist), 4)
 
 
 if __name__ == '__main__':

--- a/tests/test_spherex_image.py
+++ b/tests/test_spherex_image.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from astropy import units as u
+from astropy.io import fits
+from astropy.nddata import CCDData
+from spherex.core import SPHERExImage, spherex_image_reader, spherex_image_writer
+
+TESTDIR = os.path.dirname(__file__)
+
+
+class TestSPHERExImage(unittest.TestCase):
+    root = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.root = tempfile.mkdtemp(dir=TESTDIR)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.root is not None:
+            shutil.rmtree(cls.root, ignore_errors=True)
+
+    def test_read_write(self):
+        file_path = os.path.join(TESTDIR, "data", "small.fits")
+
+        # read multi-extension FITS file with
+        # data in the first extension
+        # flags - in the second
+        # uncertainty - in the third
+        spherex_image = spherex_image_reader(file_path, unit=(u.electron/u.s),
+                                             hdu_uncertainty=3,
+                                             hdu_flags=2)
+
+        self.assertTrue(isinstance(spherex_image, SPHERExImage))
+        self.assertTrue(isinstance(spherex_image, CCDData))
+        self.assertTrue(spherex_image.data is not None)
+        self.assertTrue(spherex_image.flags is not None)
+        self.assertEqual(len(spherex_image.flag_defs), 9)
+
+        # convert SPHEREx image object into multi-extension FITS file
+        out_path = os.path.join(self.root, "small.fits")
+        spherex_image_writer(spherex_image, out_path, hdu_uncertainty='VARIANCE',
+                             hdu_flags='FLAGS', wcs_relax=True, key_uncertainty_type='UTYPE')
+
+        with fits.open(out_path) as hdulist:
+            # Primary extension contains data
+            # second extension - variance
+            # third extension - mask
+            self.assertEqual(len(hdulist), 3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/SP-69
- added SPHERExImage class based on CCDData, which adds implementation for reading and writing bit flags
- unit_test overrides datastore configuration in butler, since it refers to the dimensions that are not defined in SPHEREx

The image class is in `python/spherex/core/spherex_image.py`. It is based on CCDData and adds LSST-like flags definitions: each flag is represented by a bit, bit values are stored in header cards. 
The image is multi-extension FITS, which includes header-only primary hdu, image, uncertainty, and flags. `tests/test_spherex_image.py` is a test for it. 

The formatters that translate between file and python representation of the image are in `python/spherex/formatters`. Currently, there are 3 formatters for image represented as HDUList, CCDData, and SPHERExImage. `tests/test_formatters.py` tests butler put/get for all of them and ingest for SPHERExImage. The tests are run automatically with GitHub action, defined in `.github/workflows/unit_test.yaml`.